### PR TITLE
Improvements in make_bulk 

### DIFF
--- a/scarf/datastore/base_datastore.py
+++ b/scarf/datastore/base_datastore.py
@@ -273,7 +273,7 @@ class BaseDataStore:
         return None
 
     def _get_assay(
-        self, from_assay: str
+        self, from_assay: Union[str, None],
     ) -> Union[Assay, RNAassay, ADTassay, ATACassay]:
         """This is a convenience function used internally to quickly obtain the
         assay object that is linked to an assay name.


### PR DESCRIPTION
Rewrote `make_bulk` method of `DataStore` to support:
- pseudobulking using either raw or normalized counts
- When bulking using raw counts the values from cells are summed while when using normalized data, mean of values across the cells is calculated.
- Added ability for secondary grouping
- Added calculation of fraction of cells expressing features.
- Improved handling of the output dataframe indices