### PR TITLE
using ThreadPoolExecutor instead of ThreadPool to avoid semlock

### DIFF
--- a/scarf/utils.py
+++ b/scarf/utils.py
@@ -173,10 +173,10 @@ def controlled_compute(arr, nthreads):
     Returns:
         Result of computation.
     """
-    from multiprocessing.pool import ThreadPool
     import dask
+    from concurrent.futures import ThreadPoolExecutor
 
-    with dask.config.set(schedular="threads", pool=ThreadPool(nthreads)):  # type: ignore
+    with dask.config.set(schedular="threads", pool=ThreadPoolExecutor(nthreads)):  # type: ignore
         res = arr.compute()
     return res
 

--- a/scarf/utils.py
+++ b/scarf/utils.py
@@ -176,6 +176,8 @@ def controlled_compute(arr, nthreads):
     import dask
 
     try:
+        # Multiprocessing may be faster, but it throws exception if SemLock is not implemented.
+        # For example, multiprocessing won't work on AWS Lambda, in those scenarios we switch ThreadPoolExecutor
         from multiprocessing.pool import ThreadPool
 
         pool = ThreadPool(nthreads)

--- a/scarf/utils.py
+++ b/scarf/utils.py
@@ -174,9 +174,17 @@ def controlled_compute(arr, nthreads):
         Result of computation.
     """
     import dask
-    from concurrent.futures import ThreadPoolExecutor
 
-    with dask.config.set(schedular="threads", pool=ThreadPoolExecutor(nthreads)):  # type: ignore
+    try:
+        from multiprocessing.pool import ThreadPool
+
+        pool = ThreadPool(nthreads)
+    except Exception:
+        from concurrent.futures import ThreadPoolExecutor
+
+        pool = ThreadPoolExecutor(nthreads)
+
+    with dask.config.set(schedular="threads", pool=pool):  # type: ignore
         res = arr.compute()
     return res
 


### PR DESCRIPTION
ThreadPool uses semlock which causes an error when using AWS Lambda