### PR TITLE
Fixes for parallell runs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ numcodecs
 umap-learn
 scikit-learn
 scikit-network
-scipy
+scipy==1.11.0
 statsmodels
 seaborn
 tqdm

--- a/scarf/datastore/datastore.py
+++ b/scarf/datastore/datastore.py
@@ -374,6 +374,13 @@ class DataStore(MappingDatastore):
         if n_threads is None:
             n_threads = self.nthreads
         assay = self._get_assay(from_assay)
+
+        slot_name = f"{cell_key}__{group_key}"
+        z = self.zw[assay.name]
+        if "markers" not in z:
+            z.create_group("markers")
+        group = z["markers"].create_group(slot_name, overwrite=True)
+
         markers = find_markers_by_rank(
             assay=assay,
             group_key=group_key,
@@ -385,11 +392,7 @@ class DataStore(MappingDatastore):
             n_threads=n_threads,
             **norm_params,
         )
-        z = self.zw[assay.name]
-        slot_name = f"{cell_key}__{group_key}"
-        if "markers" not in z:
-            z.create_group("markers")
-        group = z["markers"].create_group(slot_name, overwrite=True)
+
         for i in markers:
             g = group.create_group(i)
             vals = markers[i]

--- a/scarf/metadata.py
+++ b/scarf/metadata.py
@@ -1,5 +1,6 @@
 """Contains the MetaData class, which is used for storing metadata about cells
 and features."""
+
 import re
 from typing import List, Iterable, Any, Dict, Tuple, Optional, Union
 import numpy as np
@@ -61,7 +62,10 @@ class MetaData:
         """
         sizes = []
         for i in zgrp.keys():
-            sizes.append(zgrp[i].shape[0])
+            try:
+                sizes.append(zgrp[i].shape[0])
+            except Exception:
+                pass
         if len(sizes) > 0:
             if len(set(sizes)) != 1:
                 raise ValueError(

--- a/scarf/plots.py
+++ b/scarf/plots.py
@@ -467,7 +467,7 @@ def _scatter_fix_mask(v: pd.Series, mask_vals: list, mask_name: str) -> pd.Serie
 def _scatter_make_colors(
     v: pd.Series, cmap, color_key: Optional[dict], mask_color: str, mask_name: str
 ):
-    from matplotlib.cm import get_cmap
+    from matplotlib.pyplot import get_cmap
 
     na_idx = v == mask_name
     uv = v[~na_idx].unique()


### PR DESCRIPTION
* Create `markers/{slot_name}` early in `run_marker_search` so other processes can detect that marker search is in progress for this slot.
* Add `try` in `__get_size` for Metadata. This mitigates issues that can happen when another process is currently writing a zarr group to the hierarchy.