### PR TITLE
Use target cell_key when mapping

### DIFF
--- a/scarf/mapping_utils.py
+++ b/scarf/mapping_utils.py
@@ -88,7 +88,7 @@ def coral(source_data, target_data, assay, feat_key: str, cell_key: str, nthread
     dask_to_zarr(
         data,
         assay.z["/"],
-        f"{assay.z.name}/normed__${cell_key}__{feat_key}/data_coral",
+        f"{assay.z.name}/normed__{cell_key}__{feat_key}/data_coral",
         1000,
         nthreads,
         msg="Writing out coral corrected data",


### PR DESCRIPTION
Allow for a `target_cell_key` to be passed into `run_mapping`