### PR TITLE
ZarrMerge writer import for backwards compatibility.

### DIFF
--- a/scarf/merge.py
+++ b/scarf/merge.py
@@ -35,7 +35,7 @@ from .writers import create_zarr_count_assay, create_zarr_obj_array
 __all__ = [
     "DatasetMerge",
     "AssayMerge",
-    "ZarrMerge",
+    # "ZarrMerge",
 ]
 
 
@@ -640,16 +640,16 @@ class AssayMerge:
 
 
 # Alias for ZarrMerge
-class ZarrMerge(AssayMerge):
-    """
-    Alias for AssayMerge for backward compatibility.
-    """
+# class ZarrMerge(AssayMerge):
+#     """
+#     Alias for AssayMerge for backward compatibility.
+#     """
 
-    def __init__(self, *args, **kwargs):
-        logger.warning(
-            "The 'ZarrMerge' class is deprecated and will be removed in a future release. Please use 'AssayMerge' instead."
-        )
-        super().__init__(*args, **kwargs)
+#     def __init__(self, *args, **kwargs):
+#         logger.warning(
+#             "The 'ZarrMerge' class is deprecated and will be removed in a future release. Please use 'AssayMerge' instead."
+#         )
+#         super().__init__(*args, **kwargs)
 
 
 class DatasetMerge:

--- a/scarf/writers.py
+++ b/scarf/writers.py
@@ -19,7 +19,11 @@
 """
 
 import os
-from typing import Any, Tuple, List, Union, Dict, Optional
+from typing import Any, Tuple, List, Union, Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .merge import AssayMerge
+
 
 import numpy as np
 import pandas as pd
@@ -52,8 +56,8 @@ __all__ = [
     "to_h5ad",
     "to_mtx",
     "CSVtoZarr",
+    "ZarrMerge"
 ]
-
 
 def create_zarr_dataset(
     g: zarr.Group,
@@ -241,6 +245,25 @@ def sparse_writer(store: zarr.Array, data_stream, n_cells: int, batch_size: int)
         s = e
     return e
 
+
+def _import_merge():
+    from .merge import AssayMerge
+    return AssayMerge
+
+# Alias for ZarrMerge
+class ZarrMerge:
+    """
+    Proxy class for backward compatibility.
+    Lazily imports AssayMerge to avoid circular imports.
+    """
+    def __new__(cls, *args, **kwargs):
+        from loguru import logger
+        logger.warning(
+            "The 'ZarrMerge' class is deprecated and will be removed in a future release. "
+            "Please use 'AssayMerge' instead."
+        )
+        AssayMerge = _import_merge()
+        return AssayMerge(*args, **kwargs)
 
 class CrToZarr:
     """A class for converting data in the Cellranger format to a Zarr


### PR DESCRIPTION
Created a lazy import in `writer.py` to add compatibility for `ZarrMerge()`

```python
# Below methods are equivalent 
scarf.ZarrMerge(
   zarr_path = '',
   ...
)

scarf.writers.ZarrMerge(
   zarr_path = '',
   ...
)
```