### PR TITLE
Fixed `dask` version for better performance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ threadpoolctl
 joblib
 numba
 hnswlib
-dask[array]==2024.7.1
-zarr
+dask[array]<=2024.7.1
+zarr<=2.16.0
 h5py>=3.3.0
 umap-learn
 leidenalg

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ threadpoolctl
 joblib
 numba
 hnswlib
-dask[array]>=2024.7.1
+dask[array]==2024.7.1
 zarr
 h5py>=3.3.0
 umap-learn


### PR DESCRIPTION
We fix the `dask` version to `2024.7.1` release. All the versions after that result in worse performance.

The details of complete benchmark are available [here](https://github.com/Gautam8387/scarf-pr-exp/tree/main/04-dask-version)