### PR TITLE
Numpy 2.0 compatibility fix. pyproject.toml is uv compatible now.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dynamic = [
 ]
 
 dependencies = [
+    "cmocean>=2.1.0",
     "dask[array]<=2024.7.1",
     "h5py>=3.3.0",
     "hnswlib>=0.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,63 @@
-[build.system]
+[project]
+name = "scarf"
+version = "0.31.4"
+readme = { file = "README.rst", content-type = "text/x-rst" }
+
+dynamic = [
+    "description",
+    "requires-python",
+    "license",
+    "authors",
+    "keywords",
+    "classifiers",
+]
+
+dependencies = [
+    "dask[array]<=2024.7.1",
+    "h5py>=3.3.0",
+    "hnswlib>=0.8.0",
+    "importlib-metadata>=8.7.0",
+    "joblib>=1.5.1",
+    "leidenalg>=0.10.2",
+    "loguru>=0.7.3",
+    "networkx>=3.4.2",
+    "numba>=0.61.2",
+    "numcodecs<0.16",
+    "numpy>=1.26.4,<3.0",
+    "packaging>=25.0",
+    "pandas>=2.2.3",
+    "polars>=1.30.0",
+    "pyarrow>=20.0.0",
+    "scikit-learn>=1.6.1",
+    "scikit-network>=0.33.3",
+    "scipy>=1.15.3",
+    "setuptools>=80.9.0",
+    "statsmodels>=0.14.4",
+    "threadpoolctl>=3.6.0",
+    "tqdm>=4.67.1",
+    "umap-learn>=0.5.7",
+    "zarr<=2.16.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "requests",
+    "pytest",
+    "pytest-cov"
+]
+extra = [
+    "requests",
+    "gensim",
+    "kneed",
+    "matplotlib",
+    "seaborn",
+    "cmocean",
+    "datashader",
+    "ipython-autotime",
+    "ipywidgets"
+]
+
+[build-system]
 requires = [
     "setuptools",
     "wheel"

--- a/scarf/plots.py
+++ b/scarf/plots.py
@@ -438,15 +438,15 @@ def _scatter_fix_type(v: pd.Series, ints_as_cats: bool) -> pd.Series:
     vt = v.dtype
     if v.nunique() == 1:
         return pd.Series(np.ones(len(v)), index=v.index).astype(np.float64)
-    if vt in [np.bool_]:
+    if vt in [np.bool]:
         # converting first to int to handle bool
-        return v.astype(np.int_).astype("category")
+        return v.astype(np.int64).astype("category")
     if vt in [str, object] or vt.name == "category":
         return v.astype("category")
     elif np.issubdtype(vt.type, np.integer) and ints_as_cats:
         if v.nunique() > 100:
             logger.warning("Too many categories. set force_ints_as_cats to false")
-        return v.astype(np.int_).astype("category")
+        return v.astype(np.int64).astype("category")
     else:
         return v.astype(np.float64)
 


### PR DESCRIPTION
- Replace deprecated np.bool_ with np.bool in plots.py
- Replace deprecated np.int_ with np.int64 in plots.py
- Update numpy dependency constraint to support 1.26+ and 2.x
- Most tests pass with both NumPy 1.26.4 and 2.x