### PR TITLE
Set up Cursor Cloud dev environment for v1_prep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Scarf is a single Python library (no long-running services, no database, no web server) for memory-efficient single-cell genomics analysis. "Running the app" means importing `scarf` and exercising the analysis pipeline. This section targets the `v1_prep` branch, which uses `uv` + Python 3.14 (master still uses the legacy pip/`requirements*.txt` flow).
+
+### Environment basics
+- Dependency manager is `uv` (lockfile `uv.lock`, deps declared in `pyproject.toml`). The startup update script runs `uv sync --extra extra --extra test`, which creates `.venv/` with the core, `extra`, `test`, and `dev` (mypy/ruff) groups. Prefix commands with `uv run`.
+- `uv` is installed at `~/.local/bin` and added to PATH via `~/.bashrc`. Non-interactive shells may not pick this up; use the full path `~/.local/bin/uv` if `uv` is not found.
+- Native deps (`hnswlib`, `pcst-fast`, `scikit-network`) compile from source. The system `c++`/`cc` alternatives are pinned to GNU `g++`/`gcc`; clang is also installed but cannot find libstdc++ headers and breaks these builds. Do not switch the alternatives back to clang. If a rebuild ever fails with `'string' file not found`, set `CC=gcc CXX=g++` for that build.
+
+### Test data (not part of dependency install)
+- Tests need fixture datasets that are downloaded over the network, so they are not in the update script. Fetch once per fresh VM with: `uv run python -m tests.download_fixtures --with-h5ad` (writes to `tests/datasets/`). `--with-h5ad` also pulls a dataset from OSF; omit it to skip the OSF download.
+
+### Test / lint / run
+- Tests: `uv run pytest` (config in `pyproject.toml` runs in parallel via `-n auto` and excludes `-m 'not integration'`). `integration`-marked tests hit live network (OSF, Cloudflare R2) and are skipped by default; R2 tests also need the `SCARF_R2_*` credentials from `tests/.env`.
+- Lint: `uv run ruff check scarf`, `uv run ruff format --check scarf`, `uv run mypy scarf`. CI itself only runs pytest.
+- "Run" the library: there is no server. Build a `DataStore` from a reader/zarr and call `auto_filter_cells` -> `mark_hvgs` -> `make_graph` -> `run_leiden_clustering` -> `run_umap`. See `tests/fixtures_datastore.py` for the canonical workflow.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the Cloud Agent development environment for the `v1_prep` branch (uv + Python 3.14) and adds `AGENTS.md` documenting the non-obvious setup caveats.

This branch only adds `AGENTS.md`; no source code is modified. The environment itself is captured via the startup update script (`uv sync --extra extra --extra test`) plus one-time VM setup (system build deps, `uv`, GNU compiler alternative).

## What was verified
- `uv sync --extra extra --extra test` installs all deps (core, extra, test, dev) into `.venv` on Python 3.14.6.
- Test fixtures download via `uv run python -m tests.download_fixtures --with-h5ad`.
- Lint: `ruff check`, `ruff format --check`, `mypy` all clean.
- Tests: `uv run pytest --cov=scarf` → 219 passed (integration/network tests excluded by default).
- Hello-world end-to-end: built a `DataStore` from the CITE-seq fixture, filtered cells (808 passed), built graph, ran Leiden clustering (9 clusters) and UMAP.

## Notes / gotchas (also in AGENTS.md)
- Native deps (`hnswlib`, `pcst-fast`, `scikit-network`) compile from source. The default `c++` alternative was clang, which cannot find libstdc++ headers (`'string' file not found`); switched `c++`/`cc` to GNU `g++`/`gcc`.
- Fixture download is a network step and is intentionally not in the update script.

[hello_scarf_pipeline.log](https://cursor.com/agents/bc-4b4d1c98-2d9c-4a67-a903-cb9b886b5a1a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_scarf_pipeline.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b4d1c98-2d9c-4a67-a903-cb9b886b5a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b4d1c98-2d9c-4a67-a903-cb9b886b5a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

